### PR TITLE
[FEAT] 쿠키 기반 로그인

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
             DB_PASSWORD=${{ secrets.DB_PASSWORD }}
             JWT_SECRET=${{ secrets.JWT_SECRET }}
             DDL_AUTO=${{ secrets.DDL_AUTO }}
+            COOKIE_SECURE=true
             EOF
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker-compose pull

--- a/k6/purchase_concurrency_test.js
+++ b/k6/purchase_concurrency_test.js
@@ -60,7 +60,11 @@ export function setup() {
       continue;
     }
 
-    const accessToken = loginRes.json('payload.accessToken');
+    const accessToken = loginRes.cookies['access_token'] ? loginRes.cookies['access_token'][0].value : null;
+    if (!accessToken) {
+      console.error(`access_token 쿠키 없음 [${i}]`);
+      continue;
+    }
     tokens.push(accessToken);
   }
 
@@ -75,7 +79,7 @@ export default function (data) {
   const res = http.post(
     `${BASE_URL}/market/item/purchase`,
     null,
-    { headers: { Authorization: `Bearer ${token}` } }
+    { headers: { Cookie: `access_token=${token}` } }
   );
 
   const success = check(res, {
@@ -92,7 +96,7 @@ export default function (data) {
 // 테스트 종료 후 1회 실행 - 결과 요약
 export function teardown(data) {
   const res = http.get(`${BASE_URL}/market/item`, {
-    headers: { Authorization: `Bearer ${data.tokens[0]}` },
+    headers: { Cookie: `access_token=${data.tokens[0]}` },
   });
   if (res.status !== 200) {
     console.error(`상품 조회 실패: status=${res.status} body=${res.body}`);

--- a/src/main/java/CEOS/concurrency/common/jwt/JwtFilter.java
+++ b/src/main/java/CEOS/concurrency/common/jwt/JwtFilter.java
@@ -5,6 +5,7 @@ import CEOS.concurrency.domain.member.security.CustomUserDetailsService;
 import CEOS.concurrency.domain.payment.security.StoreUserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -71,6 +72,14 @@ public class JwtFilter extends OncePerRequestFilter {
         String bearer = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearer) && bearer.startsWith(BEARER_PREFIX)) {
             return bearer.substring(BEARER_PREFIX.length());
+        }
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("access_token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
         }
         return null;
     }

--- a/src/main/java/CEOS/concurrency/common/jwt/JwtProvider.java
+++ b/src/main/java/CEOS/concurrency/common/jwt/JwtProvider.java
@@ -68,6 +68,8 @@ public class JwtProvider {
     public String validateAndExtractSubject(String token) {
         try {
             return parseClaims(token).getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(BusinessErrorCode.TOKEN_EXPIRED);
         } catch (MalformedJwtException | UnsupportedJwtException | SignatureException e) {
             throw new BusinessException(BusinessErrorCode.TOKEN_MALFORMED);
         } catch (JwtException | IllegalArgumentException e) {

--- a/src/main/java/CEOS/concurrency/domain/market/DataInitializer.java
+++ b/src/main/java/CEOS/concurrency/domain/market/DataInitializer.java
@@ -2,6 +2,7 @@ package CEOS.concurrency.domain.market;
 
 import CEOS.concurrency.domain.market.entity.Item;
 import CEOS.concurrency.domain.market.repository.ItemRepository;
+import CEOS.concurrency.domain.market.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
@@ -11,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DataInitializer implements CommandLineRunner {
 
-    private static final int INITIAL_QUANTITY = 1000;
+    private static final int INITIAL_QUANTITY = ItemService.INITIAL_QUANTITY;
 
     private final ItemRepository itemRepository;
 

--- a/src/main/java/CEOS/concurrency/domain/market/controller/ItemController.java
+++ b/src/main/java/CEOS/concurrency/domain/market/controller/ItemController.java
@@ -28,4 +28,10 @@ public class ItemController {
     public ResponseEntity<Response<PurchaseResponse>> purchase(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(Response.of(SuccessCode.OK, itemService.purchase(userDetails.getUuid()), "상품 구매 API"));
     }
+
+    @PostMapping("/market/item/reset")
+    public ResponseEntity<Response<Void>> reset() {
+        itemService.reset();
+        return ResponseEntity.ok(Response.of(SuccessCode.OK, null, "초기화 API"));
+    }
 }

--- a/src/main/java/CEOS/concurrency/domain/market/repository/ItemRepository.java
+++ b/src/main/java/CEOS/concurrency/domain/market/repository/ItemRepository.java
@@ -11,4 +11,9 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Modifying
     @Query("UPDATE Item i SET i.quantity = :quantity WHERE i.id = :id")
     void resetQuantity(@Param("id") Long id, @Param("quantity") int quantity);
+
+    @Modifying
+    @Query(value = "INSERT INTO item (id, name, price, quantity, created_at, updated_at) " +
+            "VALUES (1, 'ChatGPT Pro 50% 할인 이용권', 10000, :quantity, NOW(), NOW())", nativeQuery = true)
+    void insertItemWithId(@Param("quantity") int quantity);
 }

--- a/src/main/java/CEOS/concurrency/domain/market/service/ItemService.java
+++ b/src/main/java/CEOS/concurrency/domain/market/service/ItemService.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 public class ItemService {
 
     public static final Long ITEM_ID = 1L;
+    public static final int INITIAL_QUANTITY = 1000;
 
     private final ItemRepository itemRepository;
     private final PurchaseLogRepository purchaseLogRepository;
@@ -61,5 +62,12 @@ public class ItemService {
         purchaseLogRepository.save(PurchaseLog.builder().item(item).member(member).build());
         item.decreaseQuantity();
         return PurchaseResponse.from(item);
+    }
+
+    @Transactional
+    public void reset() {
+        purchaseLogRepository.deleteAll();
+        itemRepository.deleteAll();
+        itemRepository.insertItemWithId(INITIAL_QUANTITY);
     }
 }

--- a/src/main/java/CEOS/concurrency/domain/member/controller/MemberController.java
+++ b/src/main/java/CEOS/concurrency/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import CEOS.concurrency.domain.member.dto.LoginResponse;
 import CEOS.concurrency.domain.member.dto.SignupRequest;
 import CEOS.concurrency.domain.member.dto.SignupResponse;
 import CEOS.concurrency.domain.member.service.MemberService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,13 +23,13 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/auth/signup")
-    public ResponseEntity<Response<SignupResponse>> signup(@RequestBody @Valid SignupRequest request) {
-        return ResponseEntity.ok(Response.of(SuccessCode.CREATE_SUCCESS, memberService.signup(request), "회원 가입 API"));
+    public ResponseEntity<Response<SignupResponse>> signup(@RequestBody @Valid SignupRequest request, HttpServletResponse response) {
+        return ResponseEntity.ok(Response.of(SuccessCode.CREATE_SUCCESS, memberService.signup(request, response), "회원 가입 API"));
     }
 
     @PostMapping("/auth/login")
-    public ResponseEntity<Response<LoginResponse>> login(@RequestBody @Valid LoginRequest request) {
-        return ResponseEntity.ok(Response.of(SuccessCode.LOGIN_SUCCESS, memberService.login(request), "로그인 API"));
+    public ResponseEntity<Response<LoginResponse>> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
+        return ResponseEntity.ok(Response.of(SuccessCode.LOGIN_SUCCESS, memberService.login(request, response), "로그인 API"));
     }
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/CEOS/concurrency/domain/member/dto/LoginResponse.java
+++ b/src/main/java/CEOS/concurrency/domain/member/dto/LoginResponse.java
@@ -1,7 +1,7 @@
 package CEOS.concurrency.domain.member.dto;
 
 public record LoginResponse(
-        String accessToken,
-        String refreshToken
+        String nickname,
+        String character
 ) {
 }

--- a/src/main/java/CEOS/concurrency/domain/member/service/MemberService.java
+++ b/src/main/java/CEOS/concurrency/domain/member/service/MemberService.java
@@ -10,13 +10,19 @@ import CEOS.concurrency.domain.member.dto.SignupResponse;
 import CEOS.concurrency.domain.member.entity.Member;
 import CEOS.concurrency.domain.member.repository.MemberRepository;
 import CEOS.concurrency.domain.member.security.CustomUserDetails;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -27,8 +33,17 @@ public class MemberService {
     private final AuthenticationManager authenticationManager;
     private final JwtProvider jwtProvider;
 
+    @Value("${jwt.access-expiration}")
+    private long accessExpiration;
+
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpiration;
+
+    @Value("${cookie.secure}")
+    private boolean cookieSecure;
+
     @Transactional
-    public SignupResponse signup(SignupRequest request) {
+    public SignupResponse signup(SignupRequest request, HttpServletResponse response) {
         if (memberRepository.findByNickname(request.nickname()).isPresent()) {
             throw new BusinessException(BusinessErrorCode.DUPLICATE_NAME);
         }
@@ -40,19 +55,31 @@ public class MemberService {
                 .build();
 
         memberRepository.save(member);
+        setTokenCookies(member.getUuid(), response);
         return SignupResponse.from(member);
     }
 
-    public LoginResponse login(LoginRequest request) {
+    public LoginResponse login(LoginRequest request, HttpServletResponse response) {
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(request.nickname(), request.password())
         );
 
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 
-        String accessToken = jwtProvider.generateAccessToken(userDetails.getUuid());
-        String refreshToken = jwtProvider.generateRefreshToken(userDetails.getUuid());
+        setTokenCookies(userDetails.getUuid(), response);
+        return new LoginResponse(userDetails.getNickname(), userDetails.getCharacterType().getEmoji());
+    }
 
-        return new LoginResponse(accessToken, refreshToken);
+    private void setTokenCookies(UUID uuid, HttpServletResponse response) {
+        String accessToken = jwtProvider.generateAccessToken(uuid);
+        String refreshToken = jwtProvider.generateRefreshToken(uuid);
+
+        ResponseCookie accessCookie = ResponseCookie.from("access_token", accessToken)
+                .httpOnly(true).secure(cookieSecure).path("/").maxAge(accessExpiration / 1000).sameSite("None").build();
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
+                .httpOnly(true).secure(cookieSecure).path("/").maxAge(refreshExpiration / 1000).sameSite("None").build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,3 +20,6 @@ jwt:
   secret: ${JWT_SECRET}
   access-expiration: 1800000
   refresh-expiration: 604800000
+
+cookie:
+  secure: ${COOKIE_SECURE:false}


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #14 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 기존 헤더에서 JWT 기반으로 인증/인가를 처리했던 방식을 쿠키 기반의 제어로 변경하였습니다.
- 로그인 방식에 맞추어 부하테스트 코드도 변경하였습니다.
- item 초기화 API를 추가하였습니다


## ⚠️ PR 특이 사항
- 이전 부하테스트를 수행하면 Deadlock 발생으로 많은 요청들이 실패했으나 토큰 기반 로그인 구현 후에는 데드락이 발생하지 않았습니다. 명확한 이유를 찾는 중입니다.
```
⏺ PostgreSQL이라서 그렇습니다.                                                                                                                                                  
                                                                                                                                                                                
  제가 설명한 데드락 패턴은 MySQL InnoDB 기준이었는데, 이 프로젝트는 PostgreSQL을 쓰고 있어요.                                                                                  
                                                                                                                                                                                
  ---                                                                                                                                                                           
  MySQL vs PostgreSQL FK 락 차이                                                                                                                                                
                                                                                                                                                                                
  MySQL InnoDB (데드락 발생)                                                                                                                                                    
  INSERT purchase_log → item row에 S lock (공유 락) 획득                                                                                                                        
  UPDATE item        → X lock 필요 → 다른 트랜잭션의 S lock과 충돌                                                                                                              
  → 서로 대기 → DEADLOCK                                                                                                                                                        
                                                                                                                                                                                
  PostgreSQL (데드락 없음)                                                                                                                                                      
  INSERT purchase_log → FK 체크 → item row에 FOR KEY SHARE lock 획득                                                                                                            
  UPDATE item (quantity 변경) → FOR NO KEY UPDATE lock 획득         
  → 두 락은 서로 호환 → 충돌 없음                                                                                                                                               
                                                                                                                                                                                
  PostgreSQL은 9.3부터 FK 체크에 FOR KEY SHARE를 사용하는데, 이건 PK/UK가 아닌 컬럼을 UPDATE할 때 획득하는 FOR NO KEY UPDATE와 호환됩니다. quantity는 PK가 아니므로 FK 체크 락과
   충돌하지 않아요.                                                                                                                                                             
                                                                                                                                                                                
  ---                                                                                                                                                                           
  결과적으로 지금 동작은:
  - 데드락 없음 (PostgreSQL FK 락 호환성)                                                                                                                                       
  - Lost Update 870건 발생 (동시성 제어 없이 MVCC 스냅샷 읽기 후 덮어쓰기)
                                                                                                                                                                                
  원래 데드락이 발생했다면 MySQL 환경이었거나, 당시 코드에 SELECT FOR UPDATE 같은 명시적 락이 있었을 가능성이 높습니다.   
```


## 📚 Reference




### ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [ ] 리뷰어 설정을 지정했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication now uses secure HTTP cookies instead of token-based headers for improved security.
  * Added an item reset endpoint for marketplace management.
  * Login response now returns user nickname and character information.

* **Bug Fixes**
  * Improved error handling for expired authentication tokens.

* **Chores**
  * Updated authentication flow to set secure cookies with enhanced cookie configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->